### PR TITLE
Logger introduced in Polyglot and exceptions inside the translate function are passed to it

### DIFF
--- a/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
@@ -22,7 +22,7 @@ use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 class ManagedTranslationProxy implements TranslatableInterface
 {
     /**
-     * @var array Cache für die Übersetzungen, indiziert nach Entity-OID und Locale.
+     * @var array<string, array<string, object|null>> Cache für die Übersetzungen, indiziert nach Entity-OID und Locale.
      * Ist static, damit ihn sich verschiedene Proxies (für die gleiche Entität, aber
      * unterschiedliche Felder) teilen können.
      */
@@ -33,6 +33,10 @@ class ManagedTranslationProxy implements TranslatableInterface
      */
     protected $entity;
 
+    /**
+     * Der einzigartige Hash für die verwaltete Entität.
+     * @var string
+     */
     protected $oid;
 
     /**
@@ -78,6 +82,16 @@ class ManagedTranslationProxy implements TranslatableInterface
      */
     protected $translationMapping;
 
+    /**
+     * @param object $entity
+     * @param string $primaryLocale
+     * @param DefaultLocaleProvider $defaultLocaleProvider
+     * @param ReflectionProperty $translatedProperty
+     * @param ReflectionProperty $translationCollection
+     * @param ReflectionClass $translationClass
+     * @param ReflectionProperty $localeField
+     * @param ReflectionProperty $translationMapping
+     */
     public function __construct(
         $entity,
         $primaryLocale,
@@ -109,6 +123,10 @@ class ManagedTranslationProxy implements TranslatableInterface
         return $this->primaryValue;
     }
 
+    /**
+     * @param string $locale
+     * @return object|null
+     */
     protected function getTranslationEntity($locale)
     {
         if ($this->isTranslationCached($locale) === false) {
@@ -118,6 +136,10 @@ class ManagedTranslationProxy implements TranslatableInterface
         return $this->getCachedTranslation($locale);
     }
 
+    /**
+     * @param $locale
+     * @return object
+     */
     protected function createTranslationEntity($locale)
     {
         $className = $this->translationClass->name;
@@ -133,6 +155,10 @@ class ManagedTranslationProxy implements TranslatableInterface
         return $entity;
     }
 
+    /**
+     * @param string $value
+     * @param string|null $locale
+     */
     public function setTranslation($value, $locale = null)
     {
         $locale = $locale ? : $this->getDefaultLocale();
@@ -147,6 +173,10 @@ class ManagedTranslationProxy implements TranslatableInterface
         }
     }
 
+    /**
+     * @param string|null $locale
+     * @return string|mixed
+     */
     public function translate($locale = null)
     {
         $locale = $locale ? : $this->getDefaultLocale();
@@ -165,11 +195,17 @@ class ManagedTranslationProxy implements TranslatableInterface
         return $this->primaryValue;
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         return (string)$this->translate();
     }
 
+    /**
+     * @return string
+     */
     protected function getDefaultLocale()
     {
         return $this->defaultLocaleProvider->getDefaultLocale();
@@ -217,7 +253,7 @@ class ManagedTranslationProxy implements TranslatableInterface
 
     /**
      * @param string $locale
-     * @return mixed
+     * @return object|null
      */
     protected function getCachedTranslation($locale)
     {

--- a/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
@@ -190,19 +190,27 @@ class ManagedTranslationProxy implements TranslatableInterface
     public function translate($locale = null)
     {
         $locale = $locale ? : $this->getDefaultLocale();
-
-        if ($locale == $this->primaryLocale) {
-            return $this->primaryValue;
-        }
-
-        if ($entity = $this->getTranslationEntity($locale)) {
-            $translated = $this->translatedProperty->getValue($entity);
-            if (null !== $translated) {
-                return $translated;
+        try {
+            if ($locale == $this->primaryLocale) {
+                return $this->primaryValue;
             }
-        }
 
-        return $this->primaryValue;
+            if ($entity = $this->getTranslationEntity($locale)) {
+                $translated = $this->translatedProperty->getValue($entity);
+                if (null !== $translated) {
+                    return $translated;
+                }
+            }
+            return $this->primaryValue;
+        } catch (\Exception $e) {
+            $message = sprintf(
+                'Cannot translate property %s::%s into locale %s',
+                get_class($this->entity),
+                $this->translatedProperty->getName(),
+                $locale
+            );
+            throw new \RuntimeException($message, 0, $e);
+        }
     }
 
     /**

--- a/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
@@ -137,7 +137,7 @@ class ManagedTranslationProxy implements TranslatableInterface
     }
 
     /**
-     * @param $locale
+     * @param string $locale
      * @return object
      */
     protected function createTranslationEntity($locale)

--- a/src/Webfactory/Bundle/PolyglotBundle/Doctrine/TranslationMetadata.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Doctrine/TranslationMetadata.php
@@ -79,6 +79,32 @@ class TranslationMetadata
         return $tm;
     }
 
+    /**
+     * @param LoggerInterface|null $logger
+     */
+    public function setLogger(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * serialize() checks if your class has a function with the magic name __sleep.
+     * If so, that function is executed prior to any serialization.
+     * It can clean up the object and is supposed to return an array with the names of all variables of that object that should be serialized.
+     * If the method doesn't return anything then NULL is serialized and E_NOTICE is issued.
+     * The intended use of __sleep is to commit pending data or perform similar cleanup tasks.
+     * Also, the function is useful if you have very large objects which do not need to be saved completely.
+     *
+     * @return array|NULL
+     * @link http://php.net/manual/en/language.oop5.magic.php#language.oop5.magic.sleep
+     */
+    function __sleep()
+    {
+        $properties = array_keys(get_object_vars($this));
+        $notSerializableProperties = array('logger');
+        return array_diff($properties, $notSerializableProperties);
+    }
+
     protected function resurrect(\ReflectionProperty $property, ReflectionService $reflectionService)
     {
         return $reflectionService->getAccessibleProperty($property->class, $property->name);

--- a/src/Webfactory/Bundle/PolyglotBundle/Doctrine/TranslationMetadata.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Doctrine/TranslationMetadata.php
@@ -13,6 +13,7 @@ use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\Mapping\ReflectionService;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Psr\Log\LoggerInterface;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 use Webfactory\Bundle\PolyglotBundle\Translatable;
 
@@ -55,6 +56,12 @@ class TranslationMetadata
      * @var string Die Locale der Werte in der Haupt-Klasse.
      */
     protected $primaryLocale;
+
+    /**
+     * @var LoggerInterface|null
+     */
+    protected $logger = null;
+
 
     public static function parseFromClassMetadata(ClassMetadataInfo $cm, Reader $reader)
     {
@@ -250,7 +257,8 @@ class TranslationMetadata
             $this->translationsCollectionProperty,
             $this->translationClass,
             $this->translationLocaleProperty,
-            $this->translationMappingProperty
+            $this->translationMappingProperty,
+            $this->logger
         );
     }
 }

--- a/src/Webfactory/Bundle/PolyglotBundle/Exception/TranslationException.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Exception/TranslationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Exception;
+
+
+class TranslationException extends \Exception
+{
+    /**
+     * TranslationException constructor.
+     * @param string $message
+     * @param \Exception $previous
+     */
+    public function __construct($message, \Exception $previous)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Webfactory/Bundle/PolyglotBundle/Resources/config/services.xml
+++ b/src/Webfactory/Bundle/PolyglotBundle/Resources/config/services.xml
@@ -15,6 +15,7 @@
                 class="%webfactory.polyglot.doctrine_listener.class%">
             <argument type="service" id="annotation_reader"/>
             <argument type="service" id="webfactory.polyglot.default_locale_provider"/>
+            <argument type="service" id="logger" on-invalid="null"/>
 
             <tag name="doctrine.event_subscriber"/>
         </service>

--- a/src/Webfactory/Bundle/PolyglotBundle/Resources/config/services.xml
+++ b/src/Webfactory/Bundle/PolyglotBundle/Resources/config/services.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="logger" on-invalid="null"/>
 
             <tag name="doctrine.event_subscriber"/>
+            <tag name="monolog.logger" channel="webfactory_polyglot_bundle"/>
         </service>
 
         <service id="webfactory.polyglot.symfony_locale_listener"

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
@@ -61,6 +61,44 @@ class ManagedTranslationProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertGreaterThan(0, count($logger->cleanLogs()), 'Expected at least one log message');
     }
 
+    public function testLoggedMessageContainsInformationAboutTranslatedProperty()
+    {
+        $entity = new TestEntity('foo');
+
+        $logger = new BufferingLogger();
+        $proxy = $this->createProxy($entity, $logger);
+        $this->breakEntity($entity);
+
+        $proxy->__toString();
+
+        $logs = $logger->cleanLogs();
+        $logEntry = current($logs);
+        $this->assertInternalType('array', $logEntry);
+        $this->assertArrayHasKey(1, $logEntry, 'Missing log message.');
+        $logMessage = $logEntry[1];
+        $this->assertContains('TestEntity', $logMessage, 'Missing entity class name.');
+        $this->assertContains('text', $logMessage, 'Missing translated property.');
+        $this->assertContains('de', $logMessage, 'Missing locale.');
+    }
+
+    public function testLoggedMessageContainsOriginalException()
+    {
+        $entity = new TestEntity('foo');
+
+        $logger = new BufferingLogger();
+        $proxy = $this->createProxy($entity, $logger);
+        $this->breakEntity($entity);
+
+        $proxy->__toString();
+
+        $logs = $logger->cleanLogs();
+        $logEntry = current($logs);
+        $this->assertInternalType('array', $logEntry);
+        $this->assertArrayHasKey(1, $logEntry, 'Missing log message.');
+        $logMessage = $logEntry[1];
+        $this->assertContains('Cannot find translations', $logMessage, 'Original exception not contained.');
+    }
+
     /**
      * @param TestEntity $entity
      * @param LoggerInterface|null $logger

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Doctrine;
+
+
+class ManagedTranslationProxyTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testToStringReturnsTranslatedMessage()
+    {
+
+    }
+
+    public function testToStringReturnsStringIfExceptionOccurredAndNoLoggerIsAvailable()
+    {
+
+    }
+
+    public function testToStringReturnsStringIfExceptionOccurredAndLoggerIsAvailable()
+    {
+
+    }
+
+    public function testToStringLogsExceptionIfLoggerIsAvailable()
+    {
+
+    }
+}

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
@@ -130,7 +130,7 @@ class ManagedTranslationProxyTest extends \PHPUnit_Framework_TestCase
      */
     private function breakEntity(TestEntity $entity)
     {
-        $brokenCollection = $this->getMock(ArrayCollection::class);
+        $brokenCollection = $this->getMock('Doctrine\Common\Collections\ArrayCollection');
         $brokenCollection->expects($this->any())
             ->method('matching')
             ->will($this->throwException(new \RuntimeException('Cannot find translations')));

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
@@ -3,6 +3,10 @@
 namespace Webfactory\Bundle\PolyglotBundle\Tests\Doctrine;
 
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Debug\BufferingLogger;
 use Webfactory\Bundle\PolyglotBundle\Doctrine\ManagedTranslationProxy;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 use Webfactory\Bundle\PolyglotBundle\Tests\TestEntity;
@@ -12,32 +16,57 @@ class ManagedTranslationProxyTest extends \PHPUnit_Framework_TestCase
 
     public function testToStringReturnsTranslatedMessage()
     {
-        $translation = (string)$this->createProxy();
+        $entity = new TestEntity('foo');
+        $proxy = $this->createProxy($entity);
+        // Simulate some translations.
+        $proxy->setTranslation('bar', 'de');
+        $proxy->setTranslation('bar in en', 'en');
+
+        $translation = (string)$proxy;
 
         $this->assertEquals('bar', $translation);
     }
 
     public function testToStringReturnsStringIfExceptionOccurredAndNoLoggerIsAvailable()
     {
+        $entity = new TestEntity('foo');
+        $proxy = $this->createProxy($entity);
+        $this->breakEntity($entity);
+        $translation = (string)$proxy;
 
+        $this->assertInternalType('string', $translation);
     }
 
     public function testToStringReturnsStringIfExceptionOccurredAndLoggerIsAvailable()
     {
+        $entity = new TestEntity('foo');
+        $proxy = $this->createProxy($entity, new NullLogger());
+        $this->breakEntity($entity);
+        $translation = (string)$proxy;
 
+        $this->assertInternalType('string', $translation);
     }
 
     public function testToStringLogsExceptionIfLoggerIsAvailable()
     {
+        $entity = new TestEntity('foo');
 
+        $logger = new BufferingLogger();
+        $proxy = $this->createProxy($entity, $logger);
+        $this->breakEntity($entity);
+
+        $proxy->__toString();
+
+        $this->assertGreaterThan(0, count($logger->cleanLogs()), 'Expected at least one log message');
     }
 
     /**
+     * @param TestEntity $entity
+     * @param LoggerInterface|null $logger
      * @return ManagedTranslationProxy
      */
-    private function createProxy()
+    private function createProxy(TestEntity $entity, LoggerInterface $logger = null)
     {
-        $entity = new TestEntity('foo');
         $localeProvider = new DefaultLocaleProvider();
         $localeProvider->setDefaultLocale('de');
 
@@ -45,18 +74,30 @@ class ManagedTranslationProxyTest extends \PHPUnit_Framework_TestCase
         $translationClass = 'Webfactory\Bundle\PolyglotBundle\Tests\TestEntityTranslation';
         $proxy = new ManagedTranslationProxy(
             $entity,
-            'de',
+            'en',
             $localeProvider,
             $this->makeAccessible(new \ReflectionProperty($translationClass, 'text')),
             $this->makeAccessible(new \ReflectionProperty($entity, 'translations')),
             new \ReflectionClass($translationClass),
             $this->makeAccessible(new \ReflectionProperty($translationClass, 'locale')),
-            $this->makeAccessible(new \ReflectionProperty($translationClass, 'entity'))
+            $this->makeAccessible(new \ReflectionProperty($translationClass, 'entity')),
+            $logger
         );
-        // Simulate a german translation.
-        $proxy->setTranslation('bar', 'de');
-        $proxy->setTranslation('bar in en', 'en');
         return $proxy;
+    }
+
+    /**
+     * @param TestEntity $entity
+     */
+    private function breakEntity(TestEntity $entity)
+    {
+        $brokenCollection = $this->getMock(ArrayCollection::class);
+        $brokenCollection->expects($this->any())
+            ->method('matching')
+            ->will($this->throwException(new \RuntimeException('Cannot find translations')));
+        $property = new \ReflectionProperty($entity, 'translations');
+        $property->setAccessible(true);
+        $property->setValue($entity, $brokenCollection);
     }
 
     /**

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
@@ -18,6 +18,7 @@ class ManagedTranslationProxyTest extends \PHPUnit_Framework_TestCase
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
+
         // Simulate some translations.
         $proxy->setTranslation('bar', 'de');
         $proxy->setTranslation('bar in en', 'en');

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
@@ -3,12 +3,18 @@
 namespace Webfactory\Bundle\PolyglotBundle\Tests\Doctrine;
 
 
+use Webfactory\Bundle\PolyglotBundle\Doctrine\ManagedTranslationProxy;
+use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
+use Webfactory\Bundle\PolyglotBundle\Tests\TestEntity;
+
 class ManagedTranslationProxyTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testToStringReturnsTranslatedMessage()
     {
+        $translation = (string)$this->createProxy();
 
+        $this->assertEquals('bar', $translation);
     }
 
     public function testToStringReturnsStringIfExceptionOccurredAndNoLoggerIsAvailable()
@@ -24,5 +30,42 @@ class ManagedTranslationProxyTest extends \PHPUnit_Framework_TestCase
     public function testToStringLogsExceptionIfLoggerIsAvailable()
     {
 
+    }
+
+    /**
+     * @return ManagedTranslationProxy
+     */
+    private function createProxy()
+    {
+        $entity = new TestEntity('foo');
+        $localeProvider = new DefaultLocaleProvider();
+        $localeProvider->setDefaultLocale('de');
+
+        // We need a translation class without required constructor parameters.
+        $translationClass = 'Webfactory\Bundle\PolyglotBundle\Tests\TestEntityTranslation';
+        $proxy = new ManagedTranslationProxy(
+            $entity,
+            'de',
+            $localeProvider,
+            $this->makeAccessible(new \ReflectionProperty($translationClass, 'text')),
+            $this->makeAccessible(new \ReflectionProperty($entity, 'translations')),
+            new \ReflectionClass($translationClass),
+            $this->makeAccessible(new \ReflectionProperty($translationClass, 'locale')),
+            $this->makeAccessible(new \ReflectionProperty($translationClass, 'entity'))
+        );
+        // Simulate a german translation.
+        $proxy->setTranslation('bar', 'de');
+        $proxy->setTranslation('bar in en', 'en');
+        return $proxy;
+    }
+
+    /**
+     * @param \ReflectionProperty $property
+     * @return \ReflectionProperty
+     */
+    private function makeAccessible(\ReflectionProperty $property)
+    {
+        $property->setAccessible(true);
+        return $property;
     }
 }

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/TranslationMetadataTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/TranslationMetadataTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Doctrine;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Webfactory\Bundle\PolyglotBundle\Doctrine\TranslationMetadata;
+
+class TranslationMetadataTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsSerializableWithoutLogger()
+    {
+        $metadata = $this->createMetadata();
+
+        $serialized = serialize($metadata);
+        $unserialized = unserialize($serialized);
+
+        $this->assertInstanceOf('Webfactory\Bundle\PolyglotBundle\Doctrine\TranslationMetadata', $unserialized);
+    }
+
+    public function testIsSerializableEvenIfInjectedLoggerIsNotSerializable()
+    {
+
+    }
+
+    /**
+     * Creates metadata for testing.
+     *
+     * @return TranslationMetadata
+     */
+    private function createMetadata()
+    {
+        $loader = function ($annotationClass) {
+            return class_exists($annotationClass, true);
+        };
+        AnnotationRegistry::registerLoader($loader);
+
+        $reader = new AnnotationReader();
+        $metadata = new ClassMetadataInfo('Webfactory\Bundle\PolyglotBundle\Tests\TestEntity');
+        $metadata->initializeReflection(new RuntimeReflectionService());
+        return TranslationMetadata::parseFromClassMetadata($metadata, $reader);
+    }
+}

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/TranslationMetadataTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/TranslationMetadataTest.php
@@ -3,10 +3,9 @@
 namespace Webfactory\Bundle\PolyglotBundle\Tests\Doctrine;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\Common\Persistence\Mapping\RuntimeReflectionService;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Psr\Log\LoggerInterface;
 use Webfactory\Bundle\PolyglotBundle\Doctrine\TranslationMetadata;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
 
 class TranslationMetadataTest extends \PHPUnit_Framework_TestCase
 {
@@ -22,24 +21,39 @@ class TranslationMetadataTest extends \PHPUnit_Framework_TestCase
 
     public function testIsSerializableEvenIfInjectedLoggerIsNotSerializable()
     {
+        $notSerializableLogger = $this->getMock('Symfony\Component\Debug\BufferingLogger', array('__sleep'));
+        $notSerializableLogger->expects($this->any())
+            ->method('__sleep')
+            ->will($this->throwException(new \RuntimeException('You cannot serialize me!')));
 
+        $metadata = $this->createMetadata($notSerializableLogger);
+
+        $serialized = serialize($metadata);
+        $unserialized = unserialize($serialized);
+
+        $this->assertInstanceOf('Webfactory\Bundle\PolyglotBundle\Doctrine\TranslationMetadata', $unserialized);
     }
 
     /**
      * Creates metadata for testing.
      *
+     * @param LoggerInterface|null $logger
      * @return TranslationMetadata
      */
-    private function createMetadata()
+    private function createMetadata(LoggerInterface $logger = null)
     {
-        $loader = function ($annotationClass) {
-            return class_exists($annotationClass, true);
-        };
-        AnnotationRegistry::registerLoader($loader);
-
         $reader = new AnnotationReader();
-        $metadata = new ClassMetadataInfo('Webfactory\Bundle\PolyglotBundle\Tests\TestEntity');
-        $metadata->initializeReflection(new RuntimeReflectionService());
-        return TranslationMetadata::parseFromClassMetadata($metadata, $reader);
+        $infrastructure = new ORMInfrastructure(
+            array(
+                '\Webfactory\Bundle\PolyglotBundle\Tests\TestEntity',
+                '\Webfactory\Bundle\PolyglotBundle\Tests\TestEntityTranslation',
+            )
+        );
+        $metadata =$infrastructure->getEntityManager()->getClassMetadata('Webfactory\Bundle\PolyglotBundle\Tests\TestEntity');
+        $translationMetadata =  TranslationMetadata::parseFromClassMetadata($metadata, $reader);
+        if ($logger !== null) {
+            $translationMetadata->setLogger($logger);
+        }
+        return $translationMetadata;
     }
 }

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/TestEntityTranslation.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/TestEntityTranslation.php
@@ -27,17 +27,21 @@ class TestEntityTranslation extends BaseTranslation
     protected $entity;
 
     /**
+     * Contains the translation.
+     *
+     * Must be protected to be usable when this class is used as base for a mock.
+     *
      * @ORM\Column(type="string")
      * @var string
      */
-    private $text;
+    protected $text;
 
     /**
-     * @param string $locale, e.g. 'de_DE'
-     * @param string $text
-     * @param TestEntity $entity
+     * @param string|null $locale, e.g. 'de_DE'
+     * @param string|null $text
+     * @param TestEntity|null $entity
      */
-    function __construct($locale, $text, TestEntity $entity)
+    function __construct($locale = null, $text = null, TestEntity $entity = null)
     {
         $this->locale = $locale;
         $this->text = $text;


### PR DESCRIPTION
Initial situation:
1. No logging was available
2. Exceptions thrown inside the translate function could not be exposed because PHP forbids __toString (which calls translate) to throw exceptions

Now:
1. A logger is passed from the PolyglotListener via the ClassMetadata to the ManagedTranslationProxy
2. Exceptions thrown inside the translate function are wrapped by a new TranslationException class and passed to the logger if one is available.