### PR TITLE
Countable translation objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
 
     "require": {
         "php": "^5.5 | ^7.0",
+        "ext-mbstring": "*",
         "doctrine/orm": "~2.2",
         "symfony/symfony": "~2.0 | ^3.0.0"
     },

--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,28 @@ For now, each entity has one fixed primary locale. We have encountered cases in 
 in a language different from the primary locale. Therefore, we want to remove the primary locale annotation and store
 this information in an attribute. This would allow each record to have its own primary locale.
 
+
+## Changelog ##
+
+### 1.1.0 -> 2.0.0 ###
+
+Instances of ``\Webfactory\Bundle\PolyglotBundle\TranslatableInterface`` must now provide a ``count()`` method that returns the length of the translation in the currently active locale.
+
+This allows the usage of translatable objects in Twig in a way that feels more like a real string: 
+
+    {# Length checks and output of length are possible now #}
+    {% if translatableObject|length > 5 %}
+        { translatableObject|length }}
+    {% endif %}
+    
+    {# Empty check works now #}
+    {% if translatableObject is not empty %}
+        {{ translatableObject }}
+    {% endif %}
+
+If you do not use your own implementation of ``\Webfactory\Bundle\PolyglotBundle\TranslatableInterface``, then you are not affected by this backward compatibility  break.
+
+
 Credits, Copyright and License
 ------------------------------
 Copyright 2012-2014 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).

--- a/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
@@ -15,6 +15,7 @@ use Psr\Log\NullLogger;
 use \ReflectionProperty;
 use \ReflectionClass;
 use Webfactory\Bundle\PolyglotBundle\Exception\TranslationException;
+use Webfactory\Bundle\PolyglotBundle\StringLengthTrait;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
@@ -24,6 +25,8 @@ use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
  */
 class ManagedTranslationProxy implements TranslatableInterface
 {
+    use StringLengthTrait;
+
     /**
      * @var array<string, array<string, object|null>> Cache für die Übersetzungen, indiziert nach Entity-OID und Locale.
      * Ist static, damit ihn sich verschiedene Proxies (für die gleiche Entität, aber
@@ -227,14 +230,6 @@ class ManagedTranslationProxy implements TranslatableInterface
             $this->logger->error($this->stringifyException($e));
             return '';
         }
-    }
-
-    /**
-     * @return integer
-     */
-    public function count()
-    {
-        return mb_strlen((string)$this, 'UTF-8');
     }
 
     /**

--- a/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
@@ -234,7 +234,7 @@ class ManagedTranslationProxy implements TranslatableInterface
      */
     public function count()
     {
-        // TODO: Implement count() method.
+        return mb_strlen((string)$this, 'UTF-8');
     }
 
     /**

--- a/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Doctrine/ManagedTranslationProxy.php
@@ -230,6 +230,14 @@ class ManagedTranslationProxy implements TranslatableInterface
     }
 
     /**
+     * @return integer
+     */
+    public function count()
+    {
+        // TODO: Implement count() method.
+    }
+
+    /**
      * @return string
      */
     protected function getDefaultLocale()

--- a/src/Webfactory/Bundle/PolyglotBundle/StringLengthTrait.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/StringLengthTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle;
+
+/**
+ * Implements the count() method of TranslatableInterface.
+ *
+ * @see TranslatableInterface
+ */
+trait StringLengthTrait
+{
+    /**
+     * @return integer
+     */
+    public function count()
+    {
+        return mb_strlen((string)$this, 'UTF-8');
+    }
+
+    /**
+     * A __toString() method is required to make this work.
+     *
+     * @return string
+     */
+    abstract public function __toString();
+}

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/Doctrine/ManagedTranslationProxyTest.php
@@ -97,6 +97,16 @@ class ManagedTranslationProxyTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Cannot find translations', $logMessage, 'Original exception not contained.');
     }
 
+    public function testCountReturnsLengthOfStringInDefaultLocale()
+    {
+        $entity = new TestEntity('foo');
+        $proxy = $this->createProxy($entity);
+        // Simulate default translation.
+        $proxy->setTranslation('bar in de', 'de');
+
+        $this->assertCount(strlen('bar in de'), $proxy);
+    }
+
     /**
      * @param TestEntity $entity
      * @param LoggerInterface|null $logger

--- a/src/Webfactory/Bundle/PolyglotBundle/Tests/TranslatableTest.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Tests/TranslatableTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests;
+
+use Webfactory\Bundle\PolyglotBundle\Translatable;
+
+class TranslatableTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * System under test.
+     *
+     * @var Translatable
+     */
+    private $translation = null;
+
+    /**
+     * Initializes the test environment.
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->translation = new Translatable('Hallo Welt!', 'de_DE');
+        $this->translation->setTranslation('en_US', 'Hello world!');
+    }
+
+    /**
+     * Cleans up the test environment.
+     */
+    protected function tearDown()
+    {
+        $this->translation = null;
+        parent::tearDown();
+    }
+
+    public function testCountReturnsLengthOfStringInDefaultLocale()
+    {
+        $this->assertCount(strlen('Hallo Welt!'), $this->translation);
+    }
+}

--- a/src/Webfactory/Bundle/PolyglotBundle/Translatable.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Translatable.php
@@ -37,6 +37,8 @@ namespace Webfactory\Bundle\PolyglotBundle;
  */
 class Translatable implements TranslatableInterface
 {
+    use StringLengthTrait;
+
     /**
      * @var string
      */
@@ -103,14 +105,6 @@ class Translatable implements TranslatableInterface
     public function __toString()
     {
         return (string)$this->translate();
-    }
-
-    /**
-     * @return integer
-     */
-    public function count()
-    {
-        return mb_strlen((string)$this, 'UTF-8');
     }
 
     /**

--- a/src/Webfactory/Bundle/PolyglotBundle/Translatable.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Translatable.php
@@ -106,6 +106,14 @@ class Translatable implements TranslatableInterface
     }
 
     /**
+     * @return integer
+     */
+    public function count()
+    {
+        // TODO: Implement count() method.
+    }
+
+    /**
      * Copies translations from this object into the given one.
      *
      * @param TranslatableInterface $p

--- a/src/Webfactory/Bundle/PolyglotBundle/Translatable.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/Translatable.php
@@ -110,7 +110,7 @@ class Translatable implements TranslatableInterface
      */
     public function count()
     {
-        // TODO: Implement count() method.
+        return mb_strlen((string)$this, 'UTF-8');
     }
 
     /**

--- a/src/Webfactory/Bundle/PolyglotBundle/TranslatableInterface.php
+++ b/src/Webfactory/Bundle/PolyglotBundle/TranslatableInterface.php
@@ -12,7 +12,7 @@ namespace Webfactory\Bundle\PolyglotBundle;
 /**
  * Represents a text with multiple translations.
  */
-interface TranslatableInterface
+interface TranslatableInterface extends \Countable
 {
     /**
      * Returns the translation for the given locale.
@@ -36,4 +36,11 @@ interface TranslatableInterface
      * @return string
      */
     public function __toString();
+
+    /**
+     * Returns the length of the translation in the current locale.
+     *
+     * @return integer
+     */
+    public function count();
 }


### PR DESCRIPTION
Introduced countable translation objects.

This BC break allows the usage of translatable objects in Twig in a way that feels more like a real string: 

    {# Length checks and output of length are possible now #}
    {% if translatableObject|length > 5 %}
        { translatableObject|length }}
    {% endif %}
    
    {# Empty check works now #}
    {% if translatableObject is not empty %}
        {{ translatableObject }}
    {% endif %}

This pull request also includes the cleanup changes. The cleanup pull request should be merged first.