### PR TITLE
Reduce priority for Doctrine event subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 To get the diff for a specific change, go to https://github.com/webfactory/polyglot-bundle/commit/XXX where XXX is the change hash. To get the diff between two versions, go to https://github.com/webfactory/polyglot-bundle/compare/{oldversion}...{newversion}.
 
+## Version 1.1.2
+
+* Changed priority for the Doctrine listener to -100 to defer injection of translation objects.
+  That should make it possible to mark fields as translatable that have
+  their value managed by other Doctrine extensions. ([GitHub PR #6](https://github.com/webfactory/polyglot-bundle/pull/6/))
+
 ## Version 1.1.1
 
 * Support for Symfony 3

--- a/src/Webfactory/Bundle/PolyglotBundle/Resources/config/services.xml
+++ b/src/Webfactory/Bundle/PolyglotBundle/Resources/config/services.xml
@@ -17,7 +17,7 @@
             <argument type="service" id="webfactory.polyglot.default_locale_provider"/>
             <argument type="service" id="logger" on-invalid="null"/>
 
-            <tag name="doctrine.event_subscriber"/>
+            <tag name="doctrine.event_subscriber" priority="-100"/>
             <tag name="monolog.logger" channel="webfactory_polyglot_bundle"/>
         </service>
 


### PR DESCRIPTION
This way I can be sure that objects that are to be translated are actually ready.